### PR TITLE
chore: add CWE ids to findings CSV

### DIFF
--- a/findings_csv.py
+++ b/findings_csv.py
@@ -13,23 +13,51 @@ findings_endpoint = urljoin(
     api_base_url, "findings/?include=compliance&length=10000"
 )
 
-response = requests.get(findings_endpoint, headers=headers)
-results = response.json()["results"]
+definitions_endpoint = urljoin(
+    api_base_url, "definitions/{definition_id}"
+)
+
+definition_cache = dict()
+
+
+def get_findings():
+    response = requests.get(findings_endpoint, headers=headers)
+    return response.json()["results"]
+
+
+def get_definition(defintion_id):
+    if definition_id in definition_cache.keys():
+        return definition_cache[defintion_id]
+
+    response = requests.get(definitions_endpoint.format(
+        defintion_id=definition_id), headers=headers)
+
+    definition_cache[definition_id] = response.json()
+    return response.json()
+
+
 with open("findings.csv", "w") as csv_file:
     csv_writer = csv.writer(
         csv_file, delimiter=",", quotechar='"', quoting=csv.QUOTE_ALL
     )
+    csv_writer.writerow(
+        "id", "severity", "cwe_id", "definition_name", "url", "last_found", "state", "assignee", "labels"
+    )
+
     for result in results:
-        labels = result["labels"] if result.get("labels") else []
+        definition = get_definition(result.get("id"))
+
+        labels = result.get("labels", [])
         labels_name = [label["name"] for label in labels]
         row = [
             result["id"],
             result["severity"],
+            definition["cwe_id"],
             result["definition"]["name"],
             result["url"],
             result["last_found"],
             result["state"],
-            result.get("assignee")["email"] if result.get("assignee") else " ",
+            result.get("assignee", {}).get("email", " "),
             *labels_name
         ]
         csv_writer.writerow(row)


### PR DESCRIPTION
Support added in both `findings_csv` and `findings_to_defectdojo`.

This information is useful to obtain in some cases, either to import into another security intelligence platform or to use as part of the vulnerability analysis.

For optimization purposes, a short "in-memory" cache is set to avoid spamming the API looking for vulnerability definition in both commands.

Also rewrote some of the logic to use Python's dictionary `.get()` with defaults instead of writing if statements, where applicable. Same result, simpler to read.


----

Another addition with the change in `findings_csv` to include a header row with the field names. 

This was useful to use personal and seemed like a nice feature to include for everyone. Obviously, you're the ones that truly know whether this would be useful for you and your users.

I can revert part of the changes if you deemed best. Ran `autopep8` in the modified files too, which added some more formatter changes but seemed the best fit for the project.

Please let me know your opinion when you have the time and thanks in advance for reviewing.